### PR TITLE
#Fix midi devices not being selected when only one is connected

### DIFF
--- a/src/midi.ts
+++ b/src/midi.ts
@@ -73,6 +73,8 @@ function onMidiInputChange(event){
       console.log('listening on ', entry.name);
     }
   });
+  input_list.selectedIndex = 0;
+  input_list.dispatchEvent(new Event('change'))
 }
 
 function onMidiChannelChange(event){


### PR DESCRIPTION
I had the problem that the `onmidimessage` was never registered on my device when I had only one connected.
This PR triggers the `onChange` event on the `input_list` such that the event handlers are always registered to the first midi device by default. 
It does not affect the behaviour when you have multiple devices connected and you can actually use the drop down select. 